### PR TITLE
Change existence check for bdf2pcf to bdftopcf

### DIFF
--- a/configure
+++ b/configure
@@ -8,7 +8,7 @@ check_existence() {
 }
 
 check_existence install
-check_existence bdf2pcf
+check_existence bdftopcf
 check_existence gzip
 check_existence rm
 


### PR DESCRIPTION
bdf2pcf has been renamed to bdftopcf, so check fails. I've updated the name so everything works now 👍 