### PR TITLE
Portability fixes for BSD systems

### DIFF
--- a/configure
+++ b/configure
@@ -116,7 +116,7 @@ clean:
 
 install: all
 	install -dm755 \$(DESTDIR)\$(installdir)
-	install -D -m 644 -t \$(DESTDIR)\$(installdir) \$(COMPILED)
+	install -m644 \$(COMPILED) \$(DESTDIR)\$(installdir)
 
 uninstall:
 	rm -f \$(INSTALLED)

--- a/configure
+++ b/configure
@@ -20,22 +20,20 @@ OBJDIR=""
 INSTALLDIR=""
 MAKEVAR="gnu"
 
-eval set -- "`getopt -o p:i:o:s:b --long prefix:,objdir:,srcdir:,installdir:,bsd-make -n "$0" -- "$@"`"
-
 while true ; do
     case "$1" in
-        -p|--prefix)
-            PREFIX="$2"; shift 2 ;;
-        -o|--objdir)
-            OBJDIR="$2"; shift 2 ;;
-        -s|--srcdir)
-            SRCDIR="$2"; shift 2 ;;
-        -b|--bsd-make)
+        --prefix=*)
+            PREFIX="${1#*=}"; shift ;;
+        --objdir=*)
+            OBJDIR="${1#*=}"; shift ;;
+        --srcdir=*)
+            SRCDIR="${1#*=}"; shift ;;
+        --bsd-make)
             MAKEVAR="bsd"; shift ;;
-        -i|--installdir)
-            INSTALLDIR="$2"; shift 2 ;;
-        --)
-            shift; break ;;
+        --installdir=*)
+            INSTALLDIR="${1#*=}"; shift ;;
+        '')
+            break ;;
         *)
             exit 1 ;;
     esac


### PR DESCRIPTION
Although generation of a BSD-style Makefile worked, it couldn't be used because of the dependency on long-flags support in `getopt`. Installation would fail as well for relying on GNU-specific `install` flags.